### PR TITLE
Avoid NPE in PostConstructAdapterFactory (#1103)

### DIFF
--- a/extras/src/main/java/com/google/gson/typeadapters/PostConstructAdapterFactory.java
+++ b/extras/src/main/java/com/google/gson/typeadapters/PostConstructAdapterFactory.java
@@ -33,7 +33,7 @@ public class PostConstructAdapterFactory implements TypeAdapterFactory {
     // copied from https://gist.github.com/swankjesse/20df26adaf639ed7fd160f145a0b661a
     @Override
     public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> type) {
-        for (Class<?> t = type.getRawType(); t != Object.class; t = t.getSuperclass()) {
+        for (Class<?> t = type.getRawType(); (t != Object.class) && (t.getSuperclass() != null); t = t.getSuperclass()) {
             for (Method m : t.getDeclaredMethods()) {
                 if (m.isAnnotationPresent(PostConstruct.class)) {
                     m.setAccessible(true);

--- a/extras/src/test/java/com/google/gson/typeadapters/PostConstructAdapterFactoryTest.java
+++ b/extras/src/test/java/com/google/gson/typeadapters/PostConstructAdapterFactoryTest.java
@@ -22,6 +22,10 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 
 import junit.framework.TestCase;
+import org.junit.Assert;
+
+import java.util.Arrays;
+import java.util.List;
 
 public class PostConstructAdapterFactoryTest extends TestCase {
     public void test() throws Exception {
@@ -37,14 +41,73 @@ public class PostConstructAdapterFactoryTest extends TestCase {
         }
     }
 
-    static class Sandwich {
-        String bread;
-        String cheese;
+    public void testList() {
+        MultipleSandwiches sandwiches = new MultipleSandwiches(Arrays.asList(
+            new Sandwich("white", "cheddar"),
+            new Sandwich("whole wheat", "swiss")));
 
-        @PostConstruct void validate() {
+        Gson gson = new GsonBuilder().registerTypeAdapterFactory(new PostConstructAdapterFactory()).create();
+
+        // Throws NullPointerException without the fix in https://github.com/google/gson/pull/1103
+        String json = gson.toJson(sandwiches);
+        Assert.assertEquals("{\"sandwiches\":[{\"bread\":\"white\",\"cheese\":\"cheddar\"},{\"bread\":\"whole wheat\",\"cheese\":\"swiss\"}]}", json);
+
+        MultipleSandwiches sandwichesFromJson = gson.fromJson(json, MultipleSandwiches.class);
+        Assert.assertEquals(sandwiches, sandwichesFromJson);
+    }
+
+    static class Sandwich {
+        public String bread;
+        public String cheese;
+
+        public Sandwich(String bread, String cheese) {
+            this.bread = bread;
+            this.cheese = cheese;
+        }
+
+        @PostConstruct private void validate() {
             if (bread.equals("cheesey bread") && cheese != null) {
                 throw new IllegalArgumentException("too cheesey");
             }
+        }
+
+        public boolean equals(Object o) {
+            if (o == this) {
+                return true;
+            }
+            if (!(o instanceof Sandwich)) {
+                return false;
+            }
+            final Sandwich other = (Sandwich) o;
+            if (this.bread == null ? other.bread != null : !this.bread.equals(other.bread)) {
+                return false;
+            }
+            if (this.cheese == null ? other.cheese != null : !this.cheese.equals(other.cheese)) {
+                return false;
+            }
+            return true;
+        }
+    }
+
+    static class MultipleSandwiches {
+        public List<Sandwich> sandwiches;
+
+        public MultipleSandwiches(List<Sandwich> sandwiches) {
+            this.sandwiches = sandwiches;
+        }
+
+        public boolean equals(Object o) {
+            if (o == this) {
+                return true;
+            }
+            if (!(o instanceof MultipleSandwiches)) {
+                return false;
+            }
+            final MultipleSandwiches other = (MultipleSandwiches) o;
+            if (this.sandwiches == null ? other.sandwiches != null : !this.sandwiches.equals(other.sandwiches)) {
+                return false;
+            }
+            return true;
         }
     }
 }


### PR DESCRIPTION
* Avoid NPE in PostConstructAdapterFactory

The RawType's Superclass might be null. This happens, for example, when the type is a collection.

* Add test case for NPE in PostConstructAdapterFactory

* Improve the code quality of PostConstructAdapterFactoryTest

* Improve the code quality of PostConstructAdapterFactoryTest

* Improve the code quality of PostConstructAdapterFactoryTest